### PR TITLE
Fixes a problem in "target" that stopped the colab link from working

### DIFF
--- a/01-an-isolated-two-state-system.ipynb
+++ b/01-an-isolated-two-state-system.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/project-ida/two-state-quantum-systems/blob/master/01-an-isolated-two-state-system.ipynb\" target=\"_parent\\\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/project-ida/two-state-quantum-systems/blob/master/01-an-isolated-two-state-system.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {


### PR DESCRIPTION
This PR modifies the `target` attribute in the colab link so that GitHub doesn't block it from loading when it's clicked on.