### PR TITLE
Fixed typo in 02 tutorial

### DIFF
--- a/02-perturbing-a-two-state-system.ipynb
+++ b/02-perturbing-a-two-state-system.ipynb
@@ -256,7 +256,7 @@
     "\n",
     "The form of the energy curve is actually a relatively simple formula $E_0 \\pm \\sqrt{A^2 + \\delta^2}$ (we won't derive this result here, but instead link you to a [lecture from Richard Feynman](https://www.feynmanlectures.caltech.edu/III_09.html#Ch9-S2)). From this we can now calculate $\\Omega = \\Delta E = 2\\sqrt{A^2 + \\delta^2} = 2\\sqrt{0.1^2 + 0.2^2} = 0.44$ giving a Rabi oscillation period of $2\\pi/\\Omega = 14$ that we saw graphically in Fig 2.\n",
     "\n",
-    "For more of a deep dive into the dependence of energy on the various parts the Hamiltonian, consult the intimately topic of [avoided crossings](https://en.wikipedia.org/wiki/Avoided_crossing).\n",
+    "For more of a deep dive into the dependence of energy on the various parts the Hamiltonian, consult the intimately connected topic of [avoided crossings](https://en.wikipedia.org/wiki/Avoided_crossing).\n",
     "\n"
    ]
   },

--- a/src/02-perturbing-a-two-state-system.md
+++ b/src/02-perturbing-a-two-state-system.md
@@ -166,7 +166,7 @@ In the extreme, as $\delta\rightarrow \infty$, the energy asymptotically approac
 
 The form of the energy curve is actually a relatively simple formula $E_0 \pm \sqrt{A^2 + \delta^2}$ (we won't derive this result here, but instead link you to a [lecture from Richard Feynman](https://www.feynmanlectures.caltech.edu/III_09.html#Ch9-S2)). From this we can now calculate $\Omega = \Delta E = 2\sqrt{A^2 + \delta^2} = 2\sqrt{0.1^2 + 0.2^2} = 0.44$ giving a Rabi oscillation period of $2\pi/\Omega = 14$ that we saw graphically in Fig 2.
 
-For more of a deep dive into the dependence of energy on the various parts the Hamiltonian, consult the intimately topic of [avoided crossings](https://en.wikipedia.org/wiki/Avoided_crossing).
+For more of a deep dive into the dependence of energy on the various parts the Hamiltonian, consult the intimately connected topic of [avoided crossings](https://en.wikipedia.org/wiki/Avoided_crossing).
 
 
 


### PR DESCRIPTION
This PR does a very simple fix to correct a typo in the 02 tutorial on perturbing a two state system