### PR TITLE
Fix small typo in introduction of tutorial 1

### DIFF
--- a/01-an-isolated-two-state-system.ipynb
+++ b/01-an-isolated-two-state-system.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "source": [
     "In this tutorial we are going to look at a single two state system that doesn't talk to the environment around it. We'll look at two examples\n",
-    "1. When system is in a stationary state\n",
+    "1. When the system is in a stationary state\n",
     "2. When the two states are coupled together"
    ]
   },

--- a/src/01-an-isolated-two-state-system.md
+++ b/src/01-an-isolated-two-state-system.md
@@ -20,7 +20,7 @@ jupyter:
 
 
 In this tutorial we are going to look at a single two state system that doesn't talk to the environment around it. We'll look at two examples
-1. When system is in a stationary state
+1. When the system is in a stationary state
 2. When the two states are coupled together
 
 ```python


### PR DESCRIPTION
This PR
- Fixes a missing `the` in the intro section of tutorial 1