### PR TITLE
Fixes broken link and updates jupytext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+.virtual_documents
 
 # IPython
 profile_default/

--- a/01-an-isolated-two-state-system.ipynb
+++ b/01-an-isolated-two-state-system.ipynb
@@ -330,7 +330,7 @@
     "\n",
     "This behaviour is identical to a system of two coupled pendulums - each state in the quantum system is analagous to one of the pendulums. If you displace only one pendulum, then its maximum amplitude oscillates slowly as it transfers energy to the second pendulum and then back again (as you can see in this [video](https://youtu.be/CjJVBvDNxcE?t=56)).\n",
     "\n",
-    "In the language of classical physics, this slow oscillation of the maximum amplitude results from the [beating](https://en.wikipedia.org/wiki/Beat_(acoustics%29) of two frequencies that correspond to different [normal modes](https://www.physics.utoronto.ca/~sandra/PHY238Y/Lectures/Lect4_Coupl_osc.pdf). These modes can be distinguished when you displace both pendulums, first in phase and then out of phase (see [this video](https://youtu.be/CjJVBvDNxcE?t=14)). \n",
+    "In the language of classical physics, this slow oscillation of the maximum amplitude results from the [beating](https://en.wikipedia.org/wiki/Beat_%28acoustics%29) of two frequencies that correspond to different [normal modes](https://www.physics.utoronto.ca/~sandra/PHY238Y/Lectures/Lect4_Coupl_osc.pdf). These modes can be distinguished when you displace both pendulums, first in phase and then out of phase (see [this video](https://youtu.be/CjJVBvDNxcE?t=14)). \n",
     "\n",
     "In the absence of coupling, there are also two frequencies in the system, but they are identical because the pendulums are identical. In effect, the coupling splits the two frequencies apart and that is also what's happening in our quantum system.\n",
     "\n",
@@ -562,7 +562,7 @@
    "formats": "ipynb,src//md"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -576,7 +576,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/src/01-an-isolated-two-state-system.md
+++ b/src/01-an-isolated-two-state-system.md
@@ -5,10 +5,10 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.3.3
+      format_version: '1.3'
+      jupytext_version: 1.14.7
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
 ---
@@ -208,7 +208,7 @@ Although we again initialised the system in the $|+>$ state, the probability to 
 
 This behaviour is identical to a system of two coupled pendulums - each state in the quantum system is analagous to one of the pendulums. If you displace only one pendulum, then its maximum amplitude oscillates slowly as it transfers energy to the second pendulum and then back again (as you can see in this [video](https://youtu.be/CjJVBvDNxcE?t=56)).
 
-In the language of classical physics, this slow oscillation of the maximum amplitude results from the [beating](https://en.wikipedia.org/wiki/Beat_(acoustics%29) of two frequencies that correspond to different [normal modes](https://www.physics.utoronto.ca/~sandra/PHY238Y/Lectures/Lect4_Coupl_osc.pdf). These modes can be distinguished when you displace both pendulums, first in phase and then out of phase (see [this video](https://youtu.be/CjJVBvDNxcE?t=14)). 
+In the language of classical physics, this slow oscillation of the maximum amplitude results from the [beating](https://en.wikipedia.org/wiki/Beat_%28acoustics%29) of two frequencies that correspond to different [normal modes](https://www.physics.utoronto.ca/~sandra/PHY238Y/Lectures/Lect4_Coupl_osc.pdf). These modes can be distinguished when you displace both pendulums, first in phase and then out of phase (see [this video](https://youtu.be/CjJVBvDNxcE?t=14)). 
 
 In the absence of coupling, there are also two frequencies in the system, but they are identical because the pendulums are identical. In effect, the coupling splits the two frequencies apart and that is also what's happening in our quantum system.
 

--- a/src/README.md
+++ b/src/README.md
@@ -9,24 +9,30 @@ Notebook meta data and outputs are removed and the remaining content is converte
 ## Why do we need notebook source files?
 Without some kind of source file, version control of notebooks is extremely difficult.
 
-## How are these source files created?
-
-The files are automatically generated using [Jupytext](https://github.com/mwouts/jupytext) in conjunction with Jupyter Lab.
-
-Jupytext has a nice [online demo](https://mybinder.org/v2/gh/mwouts/jupytext/master?urlpath=lab/tree/demo/get_started.ipynb) to help you get familiar with the [Jupytext commands](https://github.com/mwouts/jupytext#jupytext-commands-in-jupyterlab).
 
 
 
-## How do I create source files locally?
 
-A simple `pip install jupytext` should be all you need to activate the Jupytext commands in your local Jupyter lab. If this doesn't work then go to `settings`, `enable extension manager`. From there you can search for and install the Jupytext plugin manually.
+## How do I create / update source files?
 
-If you follow the instructions in the [online demo](https://mybinder.org/v2/gh/mwouts/jupytext/master?urlpath=lab/tree/demo/get_started.ipynb)  then you will generate some nice source files. The final step that's required to place the source files inside a subdirectory called `src` is to open up the notebook as a raw text file, navigate to the bottom and modify the jupytext part of the meta data to look like this:
+We use [Jupytext](https://github.com/mwouts/jupytext) to pair `.ipynb` files with `.md` files. Once the pairing is set-up once, you'll never have to worry about it again - the two files will be kept in sync.
 
-```
-"jupytext": {
-   "formats": "ipynb,src//md"
-  }
-```
+You'll need to have `jupytext` installed and also the jupytext jupyter lab extension. A simple `pip install jupytext` should sort out both requirements.
 
-I'm sorry for this last part - it a bit annoying, but currently unavoidable.
+To check this has worked, open the command palette in jupyter lab via `View -> Activate Command Palette` and type `jupytext`. If you see references to e.g. "Pair Notebook..." then all is good. If this doesn't work, go to `Settings -> Enable Extension Manager`. From there, you can search for and install the Jupytext plugin manually via `View -> Extension Manager`.
+
+To pair a notebook with a source file and make sure that source file ends up in the `src` folder:
+- Open a new notebook
+- Open the command palette
+- Type `Pair Notebook` and select `Pair Notebook with Markdown` option
+- Close the notebook
+- Open the notebook in a plain text editor
+- Navigate to the bottom and modify the jupytext part of the meta data to look like this:
+  ```
+  "jupytext": {
+    "formats": "ipynb,src//md"
+    }
+  ```
+- Open the notebook in Jupyter lab and hit the save button - a new source file should appear in the `src` folder
+- Delete any additional source files that might have been accidentally created in the root directory
+- Commit your changes to the repo


### PR DESCRIPTION
A small update to test that Jupytext still works for generating source files for good version control of notebooks. This PR:
- Fixes a broken link in notebook 1
- Excludes a folder that appears to now be generated as part of jupytext
- Updates docs for generating the source files