### PR TITLE
Updates explanation of moving along the hinton diagram

### DIFF
--- a/04-spin-boson-model.ipynb
+++ b/04-spin-boson-model.ipynb
@@ -837,7 +837,7 @@
     "\n",
     "How are the states connected? In other words - how do we move across the Hinton diagram? In short, we can only move horizontally and vertically. In more detail:\n",
     "1. Pick a starting state from the list on the x-axis $|\\psi>$\n",
-    "2. Move vertically down the Hinton diagram until you reach the diagonal - this matrix element, $<\\psi|H|\\psi>$, represents the energy of the system when it's in the $|\\psi>$ state\n",
+    "2. Move vertically along the Hinton diagram until you reach the diagonal - this matrix element, $<\\psi|H|\\psi>$, represents the energy of the system when it's in the $|\\psi>$ state\n",
     "3. Move horizontally until you meet a coloured square - this matrix element, $<\\psi|H|\\phi>$,  represents the interaction energy between $|\\psi>$  and $|\\phi>$\n",
     "4. Repeat step 2\n",
     "\n",

--- a/src/04-spin-boson-model.md
+++ b/src/04-spin-boson-model.md
@@ -378,7 +378,7 @@ If we now take a closer look at the structure of the Hinton diagram we can see s
 
 How are the states connected? In other words - how do we move across the Hinton diagram? In short, we can only move horizontally and vertically. In more detail:
 1. Pick a starting state from the list on the x-axis $|\psi>$
-2. Move vertically down the Hinton diagram until you reach the diagonal - this matrix element, $<\psi|H|\psi>$, represents the energy of the system when it's in the $|\psi>$ state
+2. Move vertically along the Hinton diagram until you reach the diagonal - this matrix element, $<\psi|H|\psi>$, represents the energy of the system when it's in the $|\psi>$ state
 3. Move horizontally until you meet a coloured square - this matrix element, $<\psi|H|\phi>$,  represents the interaction energy between $|\psi>$  and $|\phi>$
 4. Repeat step 2
 


### PR DESCRIPTION
Moving vertically along the hinton diagram can be done upwards as well as downwards. I therefore removed references to moving "down"