### PR TITLE
Updates to tutorial 10 on deep strong coupling 

### DIFF
--- a/.github/workflows/notebook-automation.yml
+++ b/.github/workflows/notebook-automation.yml
@@ -12,27 +12,43 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          fetch-depth: 2
           ssh-key: ${{ secrets.ACTIONS_BOT_KEY }}
 
       - name: Identify Modified and Deleted Notebooks
         run: |
+          echo "Current SHA: ${{ github.sha }}"
+          echo "Before SHA: ${{ github.event.before }}"
           if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
             echo "First push to this branch. Checking for parents."
-            if git log --pretty=%P -n 1 ${{ github.sha }} | grep -q .; then
-              echo "Commit has parent(s). Diffing against first parent."
-              git diff --name-status ${{ github.sha }}^ ${{ github.sha }} | grep '\.ipynb$' > notebook_changes.txt
+            parent_sha=$(git log --pretty=%P -n 1 ${{ github.sha }} | cut -d' ' -f1)
+            echo "Parent SHA: $parent_sha"
+            if [ -n "$parent_sha" ]; then
+              echo "Commit has parent: $parent_sha. Diffing against it."
+              if ! git cat-file -e "$parent_sha^{commit}" 2>/dev/null; then
+                echo "Parent not in shallow clone. Fetching."
+                git fetch origin "$parent_sha" --depth=1
+              fi
+              git diff --name-status "$parent_sha" "${{ github.sha }}" | grep '\.ipynb$' > notebook_changes.txt
             else
               echo "No parent (orphan branch). Diffing against empty tree."
-              git diff --name-status 4b825dc642cb6eb9a060e54bf8d69288fbee4904 ${{ github.sha }} | grep '\.ipynb$' > notebook_changes.txt
+              git diff --name-status 4b825dc642cb6eb9a060e54bf8d69288fbee4904 "${{ github.sha }}" | grep '\.ipynb$' > notebook_changes.txt
             fi
           else
-            if git cat-file -e ${{ github.event.before }}^{commit} 2>/dev/null; then
-              git diff --name-status ${{ github.event.before }} ${{ github.sha }} | grep '\.ipynb$' > notebook_changes.txt
+            if git cat-file -e "${{ github.event.before }}^{commit}" 2>/dev/null; then
+              echo "Diffing against previous commit: ${{ github.event.before }}"
+              git diff --name-status "${{ github.event.before }}" "${{ github.sha }}" | grep '\.ipynb$' > notebook_changes.txt
             else
-              git fetch origin ${{ github.event.before }} --depth=1
-              git diff --name-status ${{ github.event.before }} ${{ github.sha }} | grep '\.ipynb$' > notebook_changes.txt
+              echo "Fetching previous commit: ${{ github.event.before }}"
+              git fetch origin "${{ github.event.before }}" --depth=1
+              git diff --name-status "${{ github.event.before }}" "${{ github.sha }}" | grep '\.ipynb$' > notebook_changes.txt
             fi
           fi
+          if [ ! -s notebook_changes.txt ]; then
+            echo "No notebook changes detected."
+            echo "A	.dummy.ipynb" > notebook_changes.txt
+          fi
+          echo "Contents of notebook_changes.txt:"
           cat notebook_changes.txt
 
       - name: Set up Python

--- a/10-deep-strong-coupling.ipynb
+++ b/10-deep-strong-coupling.ipynb
@@ -247,7 +247,7 @@
     "\n",
     "A full account of the correspondence between quantum systems and classical oscillators is well documented in [Briggs et.al](http://dx.doi.org/10.1103/PhysRevA.85.052111). It's helpful to give a simplified summary here. \n",
     "\n",
-    "In the quantum case, each state $|\\psi_i \\rangle$ is like a pendulum whose frequency is determined by the state's energy $E_i$ and whose amplitude is determined by the state's quantum amplitude $\\langle\\psi_i|\\psi\\rangle$ -- and hence the state's occupation probability $|\\langle\\psi_i|\\psi\\rangle|^2$. When the \"quantum pendulums\" are coupled together, instead of thinking about energy being exchanged between the pendulums, we should think in terms of exchange of occupation probability. In other words, the system makes a transition from one state to another when the pendulum amplitude moves from one pendulum to another.\n",
+    "In the quantum case, each state $|\\psi_i \\rangle$ is like a pendulum whose frequency is determined by the state's energy $E_i$ and whose amplitude is determined by the state's quantum amplitude $\\langle\\psi_i|\\psi\\rangle$ -- and hence the state's occupation probability $|\\langle\\psi_i|\\psi\\rangle|^2$. When the \"quantum pendulums\" are coupled together, instead of thinking about energy being exchanged between the pendulums, we should think in terms of exchange of occupation probability. In other words, the system makes a transition from one state to another when the pendulum amplitude moves from one pendulum to another. We already these ideas when visulising excitation transfer in [tutorial 09 (Fig. 6 and Fig. 9)](https://nbviewer.org/github/project-ida/two-state-quantum-systems/blob/master/09-destructive-interference.ipynb). \n",
     "> Aside: It should be noted that when the coupling becomes ultra-strong, the equivalent classical pendulum frequency departs from $E_i/\\hbar$ significantly. This means that although there is a formal mathematical equivalence between the the quantum and and classical systems, the classical mapping becomes more difficult to interpret the stronger the coupling gets.\n",
     "\n",
     "The Rabi probability oscillations that we've observed throughout this tutorial series are a signal that we've been operating in the \"strong coupling\" regime. Indeed, we've not included any quantum dissipation such as dephasing or decoherence in our models ($\\gamma_{\\rm diss}=0$) and so $\\gamma_{\\rm diss} \\ll \\omega_{\\rm coupling} \\ll \\omega_1,\\omega_2$ has always been satisfied.\n",
@@ -304,7 +304,7 @@
    "id": "165cfea3-3e03-4de7-b973-ea6929adf36a",
    "metadata": {},
    "source": [
-    "Ideally, we'd like to appeal to our classical pendulum picture, but this is challenging because the number of states (an hence \"quantum pendulums\") that are involved in the dynamics -- an infinite number. Each state of the system is described by combining the two states of the TLS (denoted $\\pm$) with the boson states (denoted by the number of quanta $n$). There are an infinite number of such states $|n, \\pm\\rangle$.\n",
+    "Ideally, we'd like to appeal to our classical pendulum picture, but this is challenging because the number of states (number of \"quantum pendulums\") that are involved in the dynamics -- an infinite number. Each state of the system is described by combining the two states of the TLS (denoted $\\pm$) with the boson states (denoted by the number of quanta $n$). There are an infinite number of such states $|n, \\pm\\rangle$.\n",
     "\n",
     "Thinking about infinity is hard, so let's begin with thinking about two states and see how far we get.\n",
     "\n",
@@ -635,7 +635,7 @@
    "id": "521d5dbd-1142-45ad-9e51-9c585e432af4",
    "metadata": {},
    "source": [
-    "What happens when we remove the artificial restriction of simulating only two states? How does our picture change?\n",
+    "What happens when we remove the artificial restriction of simulating only two states? In other words, how does our picture change when we allow more than one boson?\n",
     "\n",
     "A significant change is that the coupling between the states is not constant - it depends on how many field quanta $n$ we have. This is because of how the field operators work:\n",
     "\n",

--- a/10-deep-strong-coupling.ipynb
+++ b/10-deep-strong-coupling.ipynb
@@ -1365,7 +1365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 3,
    "id": "b4f1d7ff-b0db-4bc1-8dce-f401f8471d8a",
    "metadata": {},
    "outputs": [],
@@ -1419,7 +1419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 4,
    "id": "b564ede8-51cd-474f-98ff-d2328f506781",
    "metadata": {},
    "outputs": [
@@ -1443,7 +1443,7 @@
        " [  0.   0.   0.   0.   0.   0.   0.   0.   0. 109.]]"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1464,7 +1464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 5,
    "id": "bc46fda0-cd6e-47f1-98de-c75e9c84389f",
    "metadata": {},
    "outputs": [],
@@ -1481,7 +1481,7 @@
     "    bosons       =  (number + 0.5)                  # boson energy operator              𝑎†𝑎+1/2\n",
     "    interaction  = (ad + a) * sx                    # interaction energy operator        (𝑎†+𝑎)𝜎𝑥  \n",
     "    \n",
-    "    P = sz*(1j*np.pi*a.dag()*a).expm()              # parity operator \n",
+    "    P = sz*(1j*np.pi*number).expm()              # parity operator \n",
     "    P = Qobj(P.full().real, dims=P.dims)            # makes sure no small imaginary parts that can happen for larger number of bosons \n",
     "    \n",
     "    # map from QuTiP number states to |n,±> states\n",
@@ -1513,7 +1513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 6,
    "id": "a79bf5f4-ecaa-4f27-9525-3967cbb00676",
    "metadata": {},
    "outputs": [],
@@ -1525,7 +1525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 7,
    "id": "9a39ff90-356b-4465-9327-b1d8249f607b",
    "metadata": {},
    "outputs": [],
@@ -1544,7 +1544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 8,
    "id": "a5781bbd-e1bc-43c5-bdf7-e525991073ff",
    "metadata": {},
    "outputs": [
@@ -1554,7 +1554,7 @@
        "(160000, '-')"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1565,7 +1565,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 9,
    "id": "9e0c0597-fd62-4437-8c3a-072d29784919",
    "metadata": {},
    "outputs": [],
@@ -1583,7 +1583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 10,
    "id": "c4b8c3b8-338f-43b3-bf51-2e7bd8953508",
    "metadata": {},
    "outputs": [],
@@ -1593,7 +1593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 11,
    "id": "3bd70a26-68bb-43d5-b329-1cce344578f4",
    "metadata": {},
    "outputs": [],
@@ -1603,7 +1603,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 12,
    "id": "d83c103a-90d4-4754-bdb7-b3ce851989a2",
    "metadata": {},
    "outputs": [],
@@ -1613,7 +1613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 13,
    "id": "1dfe1e52-01e6-4804-beef-c8020f428bcc",
    "metadata": {},
    "outputs": [],
@@ -1625,7 +1625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 14,
    "id": "042ed4d8-fb83-47f2-b7f6-9a0008ac7794",
    "metadata": {},
    "outputs": [
@@ -1656,7 +1656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 15,
    "id": "5e189779-2447-44ef-87bc-38fa32fc8365",
    "metadata": {},
    "outputs": [
@@ -1687,7 +1687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 16,
    "id": "c0f413ae-b5ec-462a-a57e-84a414f538a1",
    "metadata": {},
    "outputs": [

--- a/10-deep-strong-coupling.ipynb
+++ b/10-deep-strong-coupling.ipynb
@@ -5,7 +5,7 @@
    "id": "97f2ce24-d34c-4838-8041-2f010670f303",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/project-ida/two-state-quantum-systems/blob/master/10-deep-strong-coupling.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href=\"https://nbviewer.org/github/project-ida/two-state-quantum-systems/blob/master/10-deep-strong-coupling.ipynb\" target=\"_parent\"><img src=\"https://nbviewer.org/static/img/nav_logo.svg\" alt=\"Open In nbviewer\" width=\"100\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/project-ida/two-state-quantum-systems/blob/tutorial-10/10-deep-strong-coupling.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href=\"https://nbviewer.org/github/project-ida/two-state-quantum-systems/blob/tutorial-10/10-deep-strong-coupling.ipynb\" target=\"_parent\"><img src=\"https://nbviewer.org/static/img/nav_logo.svg\" alt=\"Open In nbviewer\" width=\"100\"/></a>"
    ]
   },
   {

--- a/10-deep-strong-coupling.ipynb
+++ b/10-deep-strong-coupling.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "So far in this tutorial series, we've explored how two-level-systems (TLS) behave when the coupling between them is small. In general, much of the \"intuition\" for how quantum systems behave is based on small couplings in one form or another.\n",
     "\n",
-    "In this tutorial, we'll let the coupling become so strong it dominates the dynamics - so called \"Deep strong coupling\". In this regime, what's usually forbidden becomes common place. Bosons are created from no where and resonance no longer seems important! 🤯\n",
+    "In this tutorial, we'll let the coupling become so strong that it dominates the dynamics - so called \"Deep strong coupling\". In this regime, what's usually forbidden becomes common place. Bosons are created from no where and resonance no longer seems important! 🤯\n",
     "\n",
     "Ready to challenge your intuition? Let's do it!"
    ]
@@ -76,7 +76,7 @@
    "source": [
     "For the last few tutorials, we've been spending a lot of time building up capabilities for studying many TLS.\n",
     "\n",
-    "For this tutorial, we've going to return to a single TLS coupled to a quantised boson field. We've previously called this the spin-boson model, but it's also called the Rabi model. The Hamiltonian is given by:\n",
+    "For this tutorial, we're going to return to a single TLS coupled to a quantised boson field. We've previously called this the single mode spin-boson model, but it's better known as the Rabi model. The Hamiltonian is given by:\n",
     "\n",
     "$$H =  \\frac{\\Delta E}{2} \\sigma_z + \\hbar\\omega\\left(a^{\\dagger}a +\\frac{1}{2}\\right) + U\\left( a^{\\dagger} + a \\right)(\\sigma_+ + \\sigma_-)$$\n",
     "\n",
@@ -169,12 +169,12 @@
    "source": [
     "Let's consider the case (as we've done many times throughout this tutorial series) of two coupled pendulums with frequencies $\\omega_1$ and $\\omega_2$. The coupling can be described in terms of a frequency $\\omega_{\\rm coupling}$ (imagine a spring connecting the two pendulums) and dissipation can be described by a rate $\\gamma_{\\rm diss}$.\n",
     "\n",
-    "The different coupling regimes are determined by how large $\\omega_{\\rm coupling}$ is compared to $\\omega_1$, $\\omega_2$ and $\\gamma_{\\rm diss}$. The naming conventions used in the [quantum optics literature](https://www.nature.com/articles/s42254-018-0006-2) are going to be useful for us. They describe the coupling as:\n",
+    "The different coupling regimes are determined by how large $\\omega_{\\rm coupling}$ is compared to $\\omega_1$, $\\omega_2$ and the dissipation $\\gamma_{\\rm diss}$. The naming conventions used in the [quantum optics literature](https://www.nature.com/articles/s42254-018-0006-2) are going to be useful for us. They describe the coupling as:\n",
     "\n",
-    "- Weak -  $\\omega_{\\rm coupling} \\ll \\gamma_{\\rm diss} \\ll \\omega_1,\\omega_2$\n",
-    "- Strong - $\\gamma_{\\rm diss} \\ll \\omega_{\\rm coupling} \\ll \\omega_1,\\omega_2$\n",
-    "- Ultra strong - $\\gamma_{\\rm diss} \\ll \\omega_{\\rm coupling} \\sim 0.1\\times  \\omega_1,\\omega_2$\n",
-    "- Deep strong - $\\gamma_{\\rm diss} \\ll \\omega_1,\\omega_2 \\lesssim \\omega_{\\rm coupling}$"
+    "- Weak:  $\\omega_{\\rm coupling} \\ll \\gamma_{\\rm diss} \\ll \\omega_1,\\omega_2$\n",
+    "- Strong: $\\gamma_{\\rm diss} \\ll \\omega_{\\rm coupling} \\ll \\omega_1,\\omega_2$\n",
+    "- Ultra strong: $\\gamma_{\\rm diss} \\ll \\omega_{\\rm coupling} \\sim 0.1  \\omega_1,\\omega_2$\n",
+    "- Deep strong: $\\gamma_{\\rm diss} \\ll \\omega_1,\\omega_2 \\lesssim \\omega_{\\rm coupling}$"
    ]
   },
   {
@@ -214,7 +214,7 @@
    "source": [
     "### Ultra strong coupling\n",
     "\n",
-    "When the coupling is ultra strong, energy exchange happens on the time scale of a single swing of one of the pendulums.  The two natural natural frequencies - when both pendulums move in the same and in opposite directions to one another - can be noticeably discerned. The coupling is getting strong enough so that more energy can be exchanged between pendulums of different lengths. This exact boundary for this regime is somewhat artificial - there is nothing particularly special about the value $0.1 \\omega_{\\rm 1}, \\omega_2$. This value was first used as part of the quantum optics literature.\n",
+    "When the coupling is ultra strong, energy exchange happens on the time scale of a single swing of one of the pendulums.  The two natural natural frequencies - when both pendulums move in the same and in opposite directions to one another - can be noticeably discerned. The coupling is getting strong enough so that more energy can be exchanged between pendulums of different lengths. This exact boundary for this regime is somewhat artificial - there is nothing particularly special about the value $0.1 \\omega_{\\rm 1}, \\omega_2$. This value was first used as part of the [quantum optics literature](https://www.nature.com/articles/s42254-018-0006-2).\n",
     "\n",
     "\n",
     "<video src=\"img/ultra-strong-coupling-dsc.mp4\" width=\"600\" controls>\n",
@@ -245,12 +245,12 @@
    "source": [
     "### From classical to quantum \n",
     "\n",
-    "A full account of the correspondence between quantum system and classical oscillators is well documented in [Briggs et.al](http://dx.doi.org/10.1103/PhysRevA.85.052111). It's helpful to give a simplified summary here. \n",
+    "A full account of the correspondence between quantum systems and classical oscillators is well documented in [Briggs et.al](http://dx.doi.org/10.1103/PhysRevA.85.052111). It's helpful to give a simplified summary here. \n",
     "\n",
-    "In the quantum case, each state $|\\psi_i \\rangle$ is like a pendulum whose frequency is determined by the state's energy $E_i$ and whose amplitude is determined by the state's quantum amplitude $\\langle\\psi_i|\\psi\\rangle$ (and hence the state's occupation probability $|\\langle\\psi_i|\\psi\\rangle|^2$). When the quantum pendulums are coupled together, instead of thinking about energy being exchanged between the pendulums, we should think in terms of exchange of occupation probability. In other words, the system makes a transition from one state to another when the pendulum amplitude moves from one pendulum to another.\n",
-    "> It should be noted that when the coupling becomes ultra-strong, the equivalent classical pendulum frequency departs from $E_i/\\hbar$ significantly. This means that although there is a formal mathematical equivalence between the the quantum and and classical systems, the classical mapping becomes more difficult to interpret the stronger the coupling gets.\n",
+    "In the quantum case, each state $|\\psi_i \\rangle$ is like a pendulum whose frequency is determined by the state's energy $E_i$ and whose amplitude is determined by the state's quantum amplitude $\\langle\\psi_i|\\psi\\rangle$ -- and hence the state's occupation probability $|\\langle\\psi_i|\\psi\\rangle|^2$. When the \"quantum pendulums\" are coupled together, instead of thinking about energy being exchanged between the pendulums, we should think in terms of exchange of occupation probability. In other words, the system makes a transition from one state to another when the pendulum amplitude moves from one pendulum to another.\n",
+    "> Aside: It should be noted that when the coupling becomes ultra-strong, the equivalent classical pendulum frequency departs from $E_i/\\hbar$ significantly. This means that although there is a formal mathematical equivalence between the the quantum and and classical systems, the classical mapping becomes more difficult to interpret the stronger the coupling gets.\n",
     "\n",
-    "The Rabi probability oscillations that we've observed throughout this tutorial series are a signal that we've been working in the \"strong coupling\" regime. Indeed, we've not included any quantum dissipation such as dephasing or decoherence in our models ($\\gamma_{\\rm diss}=0$) and so $\\gamma_{\\rm diss} \\ll \\omega_{\\rm coupling} \\ll \\omega_1,\\omega_2$ has always been satisfied.\n",
+    "The Rabi probability oscillations that we've observed throughout this tutorial series are a signal that we've been operating in the \"strong coupling\" regime. Indeed, we've not included any quantum dissipation such as dephasing or decoherence in our models ($\\gamma_{\\rm diss}=0$) and so $\\gamma_{\\rm diss} \\ll \\omega_{\\rm coupling} \\ll \\omega_1,\\omega_2$ has always been satisfied.\n",
     "\n",
     "Now we're going to consider the deep strong coupling regime of the Rabi model."
    ]
@@ -268,7 +268,7 @@
    "id": "fb87c083-93a1-498d-877b-66e501cd78d3",
    "metadata": {},
    "source": [
-    "Much like the classical pendulum, the dynamics of the the Rabi model depend on the relative sizes of the different frequencies/energies in the system, which are represented by $\\Delta E, \\hbar\\omega, U$ in the Hamilonian:"
+    "Much like the classical pendulum, the dynamics of the the Rabi model depend on the relative magnitudes of the different frequencies/energies in the system, which are represented by $\\Delta E, \\hbar\\omega, U$ in the Hamilonian:"
    ]
   },
   {
@@ -290,7 +290,7 @@
     "\\Delta E , \\hbar \\omega \\lesssim U\n",
     "$$\n",
     "\n",
-    "Casanova first focussed on the case when the TLS is degenerate, so that $\\Delta E=0$. We'll follow their lead in order to reduce complexity in these initial stages of exploration. In this case, the condition for deep strong coupling reduces to:\n",
+    "Casanova et al. first focussed on the case when the TLS is degenerate, so that $\\Delta E=0$. We'll follow their lead in order to reduce complexity in these initial stages of exploration. In this case, the condition for deep strong coupling reduces to:\n",
     "\n",
     "$$\n",
     "1 \\lesssim \\frac{U}{\\hbar\\omega}\n",
@@ -304,11 +304,11 @@
    "id": "165cfea3-3e03-4de7-b973-ea6929adf36a",
    "metadata": {},
    "source": [
-    "Ideally, we'd like to appeal to our classical pendulum picture, but this is challenging because the number of states (aka quantum pendulums) that are involved. Each state of the system is described by combining the two states of the TLS (denoted $\\pm$) with the boson states (denoted by the number of quanta $n$). There are an infinite number of such states $|n, \\pm\\rangle$.\n",
+    "Ideally, we'd like to appeal to our classical pendulum picture, but this is challenging because the number of states (an hence \"quantum pendulums\") that are involved in the dynamics -- an infinite number. Each state of the system is described by combining the two states of the TLS (denoted $\\pm$) with the boson states (denoted by the number of quanta $n$). There are an infinite number of such states $|n, \\pm\\rangle$.\n",
     "\n",
-    "Thnking about infinity is hard, so let's begin with thinking about two states and see how far we get.\n",
+    "Thinking about infinity is hard, so let's begin with thinking about two states and see how far we get.\n",
     "\n",
-    "Let's imagine we start the system in the ground state of the TLS and in vacuum - in other words $\\psi_0 = |0,-\\rangle$. Because of parity conservation, we know that this state is only coupled to states that simultaneously flip the TLS and shift the boson number by one. The only state that satisfies this is $|1,+\\rangle$. The two states have different energies/frequencies from one another and so the pendulum set-up looks like this.\n",
+    "Let's imagine we start the system in the ground state of the TLS and in vacuum - in other words $\\psi_0 = |0,-\\rangle$. Because of parity conservation, we know that this state is only coupled to states that simultaneously flip the TLS and shift the boson number by one. The only state that satisfies this is $|1,+\\rangle$. The two states have different energies/frequencies from one another and so the equivalent pendulum set-up looks like this.\n",
     "\n",
     "![](./img/pendulums-dsc-01.png)"
    ]
@@ -318,9 +318,11 @@
    "id": "5b90e056-7dbc-47b1-856c-41162278bdac",
    "metadata": {},
    "source": [
-    "If the pendulums were weakly coupled, then we'd not expect the second pendulum to move much at all because it's natural frequency is very different from the first. For pendulums that are coupled in a deep strong way, we've already seen that one displaced pendulum will pull the other one out of equilibrium even when the natural frequencies are highly mismatched. \n",
+    "Because the initial state is $\\psi_0 =|0,-\\rangle$, its \"quantum pendulum\" has maximum amplitude. The other state $|1,+\\rangle$ has zero amplitude because it's not initially occupied.\n",
     "\n",
-    "What we can predict for the quantum system is that the vacuum state won't be stable. We're not going to be able to initialise the vacuum state and have it just sit there - other states (with potentially very different energies) are likely to get occupied.\n",
+    "If the pendulums were weakly coupled, then we'd not expect the second pendulum to move much at all because its natural frequency is very different from the first. For pendulums that are coupled in a deep strong way, we've already seen that one displaced pendulum will pull the other one out of equilibrium even when the natural frequencies are highly mismatched. \n",
+    "\n",
+    "For the quantum system, we can therefore predict that the vacuum state $|0,-\\rangle$ won't be stable. In other words, we're not going to be able to initialise the vacuum state and have it just sit there - other states with very different energies (in this case the only other state is $|1,+\\rangle$) are likely to get occupied.\n",
     "\n",
     "Our prediction seems to violate energy conservation so we should be a bit skeptical. Let's do the actual quantum calculations."
    ]
@@ -542,7 +544,7 @@
    "id": "eb9d7703-5e40-4090-9d0b-f0b6b1c76c7b",
    "metadata": {},
    "source": [
-    "Fig. 1 shows us that our picture is correct. The vacuum state \"pulls\" the other state into almost 100% occupation probability on a timescale associated with the [Rabi frequency](https://en.wikipedia.org/wiki/Vacuum_Rabi_oscillation) $\\Omega = \\sqrt{4U^2 + \\delta^2}$ where $\\delta$ is often called the \"detuning\" which is just the difference in energies of the two states. "
+    "Fig. 1 shows us that our picture is correct. The vacuum state \"pulls\" the other state into almost 100% occupation probability on a timescale associated with the [Rabi frequency](https://en.wikipedia.org/wiki/Vacuum_Rabi_oscillation) $\\Omega = \\sqrt{4U^2 + \\delta^2}$ where $\\delta$ is often called the \"detuning parameter\" which is just the difference in energies of the two states. "
    ]
   },
   {
@@ -633,7 +635,7 @@
    "id": "521d5dbd-1142-45ad-9e51-9c585e432af4",
    "metadata": {},
    "source": [
-    "What happens when we remove the artificial restriction of having only two states? How does our picture change?\n",
+    "What happens when we remove the artificial restriction of simulating only two states? How does our picture change?\n",
     "\n",
     "A significant change is that the coupling between the states is not constant - it depends on how many field quanta $n$ we have. This is because of how the field operators work:\n",
     "\n",
@@ -657,7 +659,7 @@
    "source": [
     "In general, as we increase the number of quantum states, the simple pendulum picture starts to lose exact equivalence. Notwistanding this, the pictures can still help guide our intuition.\n",
     "\n",
-    "From the picture above, we might expect that several states are going to become occupied. This would mean that several bosons get created as the amplitude of the initial $|0,-\\rangle$ pendulum moves across from left to right. There will likely be a limit to how far the amplitude spreads because of the increasing mismatch in pendulum frequencies. It's hard to predict exactly how far the spread will go because although the mismatch increases, so too does the coupling 🤷‍♂️.\n",
+    "From the picture above, we might expect that several states are going to become occupied. This would mean that several bosons get created as the amplitude of the initial $|0,-\\rangle$ pendulum moves across from left to right. There will likely be a limit to how far the amplitude spreads because of the increasing mismatch in pendulum frequencies. It's hard to predict exactly how far the spread will go because, although the mismatch increases, so too does the coupling 🤷‍♂️.\n",
     "\n",
     "Let's simulate and find out if our intuition is right.\n",
     "\n",
@@ -804,7 +806,7 @@
    "id": "a2607db5-d6bf-4204-abe3-3968cfd15022",
    "metadata": {},
    "source": [
-    "Fig. 3 shows that we've got many more states occupied that just $|1,+\\rangle$. Let's take a look at the expectation value of the boson number to see how many we've got."
+    "Fig. 3 shows that we've got many more states occupied than just $|1,+\\rangle$. Let's take a look at the expectation value of the boson number to see how many we've got."
    ]
   },
   {

--- a/src/10-deep-strong-coupling.md
+++ b/src/10-deep-strong-coupling.md
@@ -5,7 +5,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.17.0
+      jupytext_version: 1.17.1
   kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
@@ -678,7 +678,7 @@ def make_operators(max_bosons, parity=0, offset=0):
     bosons       =  (number + 0.5)                  # boson energy operator              𝑎†𝑎+1/2
     interaction  = (ad + a) * sx                    # interaction energy operator        (𝑎†+𝑎)𝜎𝑥  
     
-    P = sz*(1j*np.pi*a.dag()*a).expm()              # parity operator 
+    P = sz*(1j*np.pi*number).expm()              # parity operator 
     P = Qobj(P.full().real, dims=P.dims)            # makes sure no small imaginary parts that can happen for larger number of bosons 
     
     # map from QuTiP number states to |n,±> states

--- a/src/10-deep-strong-coupling.md
+++ b/src/10-deep-strong-coupling.md
@@ -20,7 +20,7 @@ jupyter:
 
 So far in this tutorial series, we've explored how two-level-systems (TLS) behave when the coupling between them is small. In general, much of the "intuition" for how quantum systems behave is based on small couplings in one form or another.
 
-In this tutorial, we'll let the coupling become so strong it dominates the dynamics - so called "Deep strong coupling". In this regime, what's usually forbidden becomes common place. Bosons are created from no where and resonance no longer seems important! 🤯
+In this tutorial, we'll let the coupling become so strong that it dominates the dynamics - so called "Deep strong coupling". In this regime, what's usually forbidden becomes common place. Bosons are created from no where and resonance no longer seems important! 🤯
 
 Ready to challenge your intuition? Let's do it!
 
@@ -54,7 +54,7 @@ from libs.helper_10_tutorial import *
 <!-- #region jp-MarkdownHeadingCollapsed=true -->
 For the last few tutorials, we've been spending a lot of time building up capabilities for studying many TLS.
 
-For this tutorial, we've going to return to a single TLS coupled to a quantised boson field. We've previously called this the spin-boson model, but it's also called the Rabi model. The Hamiltonian is given by:
+For this tutorial, we're going to return to a single TLS coupled to a quantised boson field. We've previously called this the single mode spin-boson model, but it's better known as the Rabi model. The Hamiltonian is given by:
 
 $$H =  \frac{\Delta E}{2} \sigma_z + \hbar\omega\left(a^{\dagger}a +\frac{1}{2}\right) + U\left( a^{\dagger} + a \right)(\sigma_+ + \sigma_-)$$
 
@@ -114,12 +114,12 @@ Before we get into the calculations, let's try and build some intuition for what
 
 Let's consider the case (as we've done many times throughout this tutorial series) of two coupled pendulums with frequencies $\omega_1$ and $\omega_2$. The coupling can be described in terms of a frequency $\omega_{\rm coupling}$ (imagine a spring connecting the two pendulums) and dissipation can be described by a rate $\gamma_{\rm diss}$.
 
-The different coupling regimes are determined by how large $\omega_{\rm coupling}$ is compared to $\omega_1$, $\omega_2$ and $\gamma_{\rm diss}$. The naming conventions used in the [quantum optics literature](https://www.nature.com/articles/s42254-018-0006-2) are going to be useful for us. They describe the coupling as:
+The different coupling regimes are determined by how large $\omega_{\rm coupling}$ is compared to $\omega_1$, $\omega_2$ and the dissipation $\gamma_{\rm diss}$. The naming conventions used in the [quantum optics literature](https://www.nature.com/articles/s42254-018-0006-2) are going to be useful for us. They describe the coupling as:
 
-- Weak -  $\omega_{\rm coupling} \ll \gamma_{\rm diss} \ll \omega_1,\omega_2$
-- Strong - $\gamma_{\rm diss} \ll \omega_{\rm coupling} \ll \omega_1,\omega_2$
-- Ultra strong - $\gamma_{\rm diss} \ll \omega_{\rm coupling} \sim 0.1\times  \omega_1,\omega_2$
-- Deep strong - $\gamma_{\rm diss} \ll \omega_1,\omega_2 \lesssim \omega_{\rm coupling}$
+- Weak:  $\omega_{\rm coupling} \ll \gamma_{\rm diss} \ll \omega_1,\omega_2$
+- Strong: $\gamma_{\rm diss} \ll \omega_{\rm coupling} \ll \omega_1,\omega_2$
+- Ultra strong: $\gamma_{\rm diss} \ll \omega_{\rm coupling} \sim 0.1  \omega_1,\omega_2$
+- Deep strong: $\gamma_{\rm diss} \ll \omega_1,\omega_2 \lesssim \omega_{\rm coupling}$
 
 
 ### Weak coupling
@@ -145,7 +145,7 @@ When the coupling is strong, the dissipation is small enough to allow energy to 
 <!-- #region -->
 ### Ultra strong coupling
 
-When the coupling is ultra strong, energy exchange happens on the time scale of a single swing of one of the pendulums.  The two natural natural frequencies - when both pendulums move in the same and in opposite directions to one another - can be noticeably discerned. The coupling is getting strong enough so that more energy can be exchanged between pendulums of different lengths. This exact boundary for this regime is somewhat artificial - there is nothing particularly special about the value $0.1 \omega_{\rm 1}, \omega_2$. This value was first used as part of the quantum optics literature.
+When the coupling is ultra strong, energy exchange happens on the time scale of a single swing of one of the pendulums.  The two natural natural frequencies - when both pendulums move in the same and in opposite directions to one another - can be noticeably discerned. The coupling is getting strong enough so that more energy can be exchanged between pendulums of different lengths. This exact boundary for this regime is somewhat artificial - there is nothing particularly special about the value $0.1 \omega_{\rm 1}, \omega_2$. This value was first used as part of the [quantum optics literature](https://www.nature.com/articles/s42254-018-0006-2).
 
 
 <video src="img/ultra-strong-coupling-dsc.mp4" width="600" controls>
@@ -164,12 +164,12 @@ When the coupling is deep strong, the coupling begins to dominate over everythin
 <!-- #region jp-MarkdownHeadingCollapsed=true -->
 ### From classical to quantum 
 
-A full account of the correspondence between quantum system and classical oscillators is well documented in [Briggs et.al](http://dx.doi.org/10.1103/PhysRevA.85.052111). It's helpful to give a simplified summary here. 
+A full account of the correspondence between quantum systems and classical oscillators is well documented in [Briggs et.al](http://dx.doi.org/10.1103/PhysRevA.85.052111). It's helpful to give a simplified summary here. 
 
-In the quantum case, each state $|\psi_i \rangle$ is like a pendulum whose frequency is determined by the state's energy $E_i$ and whose amplitude is determined by the state's quantum amplitude $\langle\psi_i|\psi\rangle$ (and hence the state's occupation probability $|\langle\psi_i|\psi\rangle|^2$). When the quantum pendulums are coupled together, instead of thinking about energy being exchanged between the pendulums, we should think in terms of exchange of occupation probability. In other words, the system makes a transition from one state to another when the pendulum amplitude moves from one pendulum to another.
-> It should be noted that when the coupling becomes ultra-strong, the equivalent classical pendulum frequency departs from $E_i/\hbar$ significantly. This means that although there is a formal mathematical equivalence between the the quantum and and classical systems, the classical mapping becomes more difficult to interpret the stronger the coupling gets.
+In the quantum case, each state $|\psi_i \rangle$ is like a pendulum whose frequency is determined by the state's energy $E_i$ and whose amplitude is determined by the state's quantum amplitude $\langle\psi_i|\psi\rangle$ -- and hence the state's occupation probability $|\langle\psi_i|\psi\rangle|^2$. When the "quantum pendulums" are coupled together, instead of thinking about energy being exchanged between the pendulums, we should think in terms of exchange of occupation probability. In other words, the system makes a transition from one state to another when the pendulum amplitude moves from one pendulum to another.
+> Aside: It should be noted that when the coupling becomes ultra-strong, the equivalent classical pendulum frequency departs from $E_i/\hbar$ significantly. This means that although there is a formal mathematical equivalence between the the quantum and and classical systems, the classical mapping becomes more difficult to interpret the stronger the coupling gets.
 
-The Rabi probability oscillations that we've observed throughout this tutorial series are a signal that we've been working in the "strong coupling" regime. Indeed, we've not included any quantum dissipation such as dephasing or decoherence in our models ($\gamma_{\rm diss}=0$) and so $\gamma_{\rm diss} \ll \omega_{\rm coupling} \ll \omega_1,\omega_2$ has always been satisfied.
+The Rabi probability oscillations that we've observed throughout this tutorial series are a signal that we've been operating in the "strong coupling" regime. Indeed, we've not included any quantum dissipation such as dephasing or decoherence in our models ($\gamma_{\rm diss}=0$) and so $\gamma_{\rm diss} \ll \omega_{\rm coupling} \ll \omega_1,\omega_2$ has always been satisfied.
 
 Now we're going to consider the deep strong coupling regime of the Rabi model.
 <!-- #endregion -->
@@ -177,7 +177,7 @@ Now we're going to consider the deep strong coupling regime of the Rabi model.
 ## 10.3 Vacuum field deep strong coupling ($n=0$)
 
 
-Much like the classical pendulum, the dynamics of the the Rabi model depend on the relative sizes of the different frequencies/energies in the system, which are represented by $\Delta E, \hbar\omega, U$ in the Hamilonian:
+Much like the classical pendulum, the dynamics of the the Rabi model depend on the relative magnitudes of the different frequencies/energies in the system, which are represented by $\Delta E, \hbar\omega, U$ in the Hamilonian:
 
 
 $$H = \frac{\Delta E}{2} \sigma_z + \hbar\omega\left(a^{\dagger}a +\frac{1}{2}\right) + U\left( a^{\dagger} + a \right)(\sigma_+ + \sigma_-)$$
@@ -189,7 +189,7 @@ $$
 \Delta E , \hbar \omega \lesssim U
 $$
 
-Casanova first focussed on the case when the TLS is degenerate, so that $\Delta E=0$. We'll follow their lead in order to reduce complexity in these initial stages of exploration. In this case, the condition for deep strong coupling reduces to:
+Casanova et al. first focussed on the case when the TLS is degenerate, so that $\Delta E=0$. We'll follow their lead in order to reduce complexity in these initial stages of exploration. In this case, the condition for deep strong coupling reduces to:
 
 $$
 1 \lesssim \frac{U}{\hbar\omega}
@@ -198,18 +198,20 @@ $$
 Before we start simulating, let's see if we can predict what will happen.
 
 
-Ideally, we'd like to appeal to our classical pendulum picture, but this is challenging because the number of states (aka quantum pendulums) that are involved. Each state of the system is described by combining the two states of the TLS (denoted $\pm$) with the boson states (denoted by the number of quanta $n$). There are an infinite number of such states $|n, \pm\rangle$.
+Ideally, we'd like to appeal to our classical pendulum picture, but this is challenging because the number of states (an hence "quantum pendulums") that are involved in the dynamics -- an infinite number. Each state of the system is described by combining the two states of the TLS (denoted $\pm$) with the boson states (denoted by the number of quanta $n$). There are an infinite number of such states $|n, \pm\rangle$.
 
-Thnking about infinity is hard, so let's begin with thinking about two states and see how far we get.
+Thinking about infinity is hard, so let's begin with thinking about two states and see how far we get.
 
-Let's imagine we start the system in the ground state of the TLS and in vacuum - in other words $\psi_0 = |0,-\rangle$. Because of parity conservation, we know that this state is only coupled to states that simultaneously flip the TLS and shift the boson number by one. The only state that satisfies this is $|1,+\rangle$. The two states have different energies/frequencies from one another and so the pendulum set-up looks like this.
+Let's imagine we start the system in the ground state of the TLS and in vacuum - in other words $\psi_0 = |0,-\rangle$. Because of parity conservation, we know that this state is only coupled to states that simultaneously flip the TLS and shift the boson number by one. The only state that satisfies this is $|1,+\rangle$. The two states have different energies/frequencies from one another and so the equivalent pendulum set-up looks like this.
 
 ![](./img/pendulums-dsc-01.png)
 
 
-If the pendulums were weakly coupled, then we'd not expect the second pendulum to move much at all because it's natural frequency is very different from the first. For pendulums that are coupled in a deep strong way, we've already seen that one displaced pendulum will pull the other one out of equilibrium even when the natural frequencies are highly mismatched. 
+Because the initial state is $\psi_0 =|0,-\rangle$, its "quantum pendulum" has maximum amplitude. The other state $|1,+\rangle$ has zero amplitude because it's not initially occupied.
 
-What we can predict for the quantum system is that the vacuum state won't be stable. We're not going to be able to initialise the vacuum state and have it just sit there - other states (with potentially very different energies) are likely to get occupied.
+If the pendulums were weakly coupled, then we'd not expect the second pendulum to move much at all because its natural frequency is very different from the first. For pendulums that are coupled in a deep strong way, we've already seen that one displaced pendulum will pull the other one out of equilibrium even when the natural frequencies are highly mismatched. 
+
+For the quantum system, we can therefore predict that the vacuum state $|0,-\rangle$ won't be stable. In other words, we're not going to be able to initialise the vacuum state and have it just sit there - other states with very different energies (in this case the only other state is $|1,+\rangle$) are likely to get occupied.
 
 Our prediction seems to violate energy conservation so we should be a bit skeptical. Let's do the actual quantum calculations.
 
@@ -285,7 +287,7 @@ plt.title(f" {H_latex}   \n $\Delta E={DeltaE}$, $\omega={omega}$, $U={U}$, $\Ps
 plt.xlabel("Time ($2\pi/\omega$)");
 ```
 
-Fig. 1 shows us that our picture is correct. The vacuum state "pulls" the other state into almost 100% occupation probability on a timescale associated with the [Rabi frequency](https://en.wikipedia.org/wiki/Vacuum_Rabi_oscillation) $\Omega = \sqrt{4U^2 + \delta^2}$ where $\delta$ is often called the "detuning" which is just the difference in energies of the two states. 
+Fig. 1 shows us that our picture is correct. The vacuum state "pulls" the other state into almost 100% occupation probability on a timescale associated with the [Rabi frequency](https://en.wikipedia.org/wiki/Vacuum_Rabi_oscillation) $\Omega = \sqrt{4U^2 + \delta^2}$ where $\delta$ is often called the "detuning parameter" which is just the difference in energies of the two states. 
 
 ```python
 rabi_omega = np.sqrt(4*U**2 + 1**2)
@@ -317,7 +319,7 @@ Fig. 2 shows is that the boson energy is being "borrowed" from interaction energ
 ### Arbitrary number of coupled states
 
 
-What happens when we remove the artificial restriction of having only two states? How does our picture change?
+What happens when we remove the artificial restriction of simulating only two states? How does our picture change?
 
 A significant change is that the coupling between the states is not constant - it depends on how many field quanta $n$ we have. This is because of how the field operators work:
 
@@ -336,7 +338,7 @@ Far from being constant, the coupling scales as $\sim 2U\sqrt{n}$. Our picture i
 
 In general, as we increase the number of quantum states, the simple pendulum picture starts to lose exact equivalence. Notwistanding this, the pictures can still help guide our intuition.
 
-From the picture above, we might expect that several states are going to become occupied. This would mean that several bosons get created as the amplitude of the initial $|0,-\rangle$ pendulum moves across from left to right. There will likely be a limit to how far the amplitude spreads because of the increasing mismatch in pendulum frequencies. It's hard to predict exactly how far the spread will go because although the mismatch increases, so too does the coupling 🤷‍♂️.
+From the picture above, we might expect that several states are going to become occupied. This would mean that several bosons get created as the amplitude of the initial $|0,-\rangle$ pendulum moves across from left to right. There will likely be a limit to how far the amplitude spreads because of the increasing mismatch in pendulum frequencies. It's hard to predict exactly how far the spread will go because, although the mismatch increases, so too does the coupling 🤷‍♂️.
 
 Let's simulate and find out if our intuition is right.
 
@@ -389,7 +391,7 @@ plt.title(f" {H_latex}   \n $\Delta E={DeltaE}$, $\omega={omega}$, $U={U}$, $\Ps
 plt.xlabel("Time ($2\pi/\omega$)");
 ```
 
-Fig. 3 shows that we've got many more states occupied that just $|1,+\rangle$. Let's take a look at the expectation value of the boson number to see how many we've got.
+Fig. 3 shows that we've got many more states occupied than just $|1,+\rangle$. Let's take a look at the expectation value of the boson number to see how many we've got.
 
 ```python
 plt.figure(figsize=(10,8))

--- a/src/10-deep-strong-coupling.md
+++ b/src/10-deep-strong-coupling.md
@@ -166,7 +166,7 @@ When the coupling is deep strong, the coupling begins to dominate over everythin
 
 A full account of the correspondence between quantum systems and classical oscillators is well documented in [Briggs et.al](http://dx.doi.org/10.1103/PhysRevA.85.052111). It's helpful to give a simplified summary here. 
 
-In the quantum case, each state $|\psi_i \rangle$ is like a pendulum whose frequency is determined by the state's energy $E_i$ and whose amplitude is determined by the state's quantum amplitude $\langle\psi_i|\psi\rangle$ -- and hence the state's occupation probability $|\langle\psi_i|\psi\rangle|^2$. When the "quantum pendulums" are coupled together, instead of thinking about energy being exchanged between the pendulums, we should think in terms of exchange of occupation probability. In other words, the system makes a transition from one state to another when the pendulum amplitude moves from one pendulum to another.
+In the quantum case, each state $|\psi_i \rangle$ is like a pendulum whose frequency is determined by the state's energy $E_i$ and whose amplitude is determined by the state's quantum amplitude $\langle\psi_i|\psi\rangle$ -- and hence the state's occupation probability $|\langle\psi_i|\psi\rangle|^2$. When the "quantum pendulums" are coupled together, instead of thinking about energy being exchanged between the pendulums, we should think in terms of exchange of occupation probability. In other words, the system makes a transition from one state to another when the pendulum amplitude moves from one pendulum to another. We already these ideas when visulising excitation transfer in [tutorial 09 (Fig. 6 and Fig. 9)](https://nbviewer.org/github/project-ida/two-state-quantum-systems/blob/master/09-destructive-interference.ipynb). 
 > Aside: It should be noted that when the coupling becomes ultra-strong, the equivalent classical pendulum frequency departs from $E_i/\hbar$ significantly. This means that although there is a formal mathematical equivalence between the the quantum and and classical systems, the classical mapping becomes more difficult to interpret the stronger the coupling gets.
 
 The Rabi probability oscillations that we've observed throughout this tutorial series are a signal that we've been operating in the "strong coupling" regime. Indeed, we've not included any quantum dissipation such as dephasing or decoherence in our models ($\gamma_{\rm diss}=0$) and so $\gamma_{\rm diss} \ll \omega_{\rm coupling} \ll \omega_1,\omega_2$ has always been satisfied.
@@ -198,7 +198,7 @@ $$
 Before we start simulating, let's see if we can predict what will happen.
 
 
-Ideally, we'd like to appeal to our classical pendulum picture, but this is challenging because the number of states (an hence "quantum pendulums") that are involved in the dynamics -- an infinite number. Each state of the system is described by combining the two states of the TLS (denoted $\pm$) with the boson states (denoted by the number of quanta $n$). There are an infinite number of such states $|n, \pm\rangle$.
+Ideally, we'd like to appeal to our classical pendulum picture, but this is challenging because the number of states (number of "quantum pendulums") that are involved in the dynamics -- an infinite number. Each state of the system is described by combining the two states of the TLS (denoted $\pm$) with the boson states (denoted by the number of quanta $n$). There are an infinite number of such states $|n, \pm\rangle$.
 
 Thinking about infinity is hard, so let's begin with thinking about two states and see how far we get.
 
@@ -319,7 +319,7 @@ Fig. 2 shows is that the boson energy is being "borrowed" from interaction energ
 ### Arbitrary number of coupled states
 
 
-What happens when we remove the artificial restriction of simulating only two states? How does our picture change?
+What happens when we remove the artificial restriction of simulating only two states? In other words, how does our picture change when we allow more than one boson?
 
 A significant change is that the coupling between the states is not constant - it depends on how many field quanta $n$ we have. This is because of how the field operators work:
 

--- a/src/10-deep-strong-coupling.md
+++ b/src/10-deep-strong-coupling.md
@@ -12,7 +12,7 @@ jupyter:
     name: python3
 ---
 
-<a href="https://colab.research.google.com/github/project-ida/two-state-quantum-systems/blob/master/10-deep-strong-coupling.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://nbviewer.org/github/project-ida/two-state-quantum-systems/blob/master/10-deep-strong-coupling.ipynb" target="_parent"><img src="https://nbviewer.org/static/img/nav_logo.svg" alt="Open In nbviewer" width="100"/></a>
+<a href="https://colab.research.google.com/github/project-ida/two-state-quantum-systems/blob/tutorial-10/10-deep-strong-coupling.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="https://nbviewer.org/github/project-ida/two-state-quantum-systems/blob/tutorial-10/10-deep-strong-coupling.ipynb" target="_parent"><img src="https://nbviewer.org/static/img/nav_logo.svg" alt="Open In nbviewer" width="100"/></a>
 
 
 # 10 - Deep strong coupling


### PR DESCRIPTION
This PR was created because the [original one](https://github.com/project-ida/two-state-quantum-systems/pull/48) was merged prematurely.

This PR updates the 10th tutorial in this series on `Deep strong coupling`. The aim is this tutorial is to introduce some ideas from our paper on  [Models for nuclear fusion in the solid state](https://arxiv.org/abs/2501.08338). Specifically the tutorial sets the scene for the "free exchange" ideas present in the paper. 

This tutorial limits the scope to looking at a degenerate TLS. The next tutorial will remove that restriction and allow us to add the next level of realism in order to get to a place where we can simulate "free exchange" in QuTiP.

As usual comments are best to the markdown file in `src` over in the [Files changed tab](https://github.com/project-ida/two-state-quantum-systems/pull/50/files).

You can see a rendered version of the notebook from this branch over on [nbviewer](https://nbviewer.org/github/project-ida/two-state-quantum-systems/blob/tutorial-10/10-deep-strong-coupling.ipynb) - this is where you'll need to go to see the videos that are embedded.